### PR TITLE
#65 Testing for common-app/componentes/header

### DIFF
--- a/front/src/common-app/components/header/header.component.spec.tsx
+++ b/front/src/common-app/components/header/header.component.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Header } from './header.component';
+
+describe('Header component spec', () => {
+  it('"HTML elements" should be displayed by default', () => {
+    // Arrange
+
+    // Act
+    render(<Header />);
+
+    const header: HTMLElement = screen.getByRole('banner');
+    const image: HTMLElement = screen.getByRole('img');
+    const heading: HTMLElement = screen.getByRole('heading', {
+      name: 'T-Shirt Planning Poker',
+    });
+
+    // Assert
+    expect(header).toBeInTheDocument();
+    expect(image).toBeInTheDocument();
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('"image" attributes should have expected values', () => {
+    // Arrange
+    const expectedSrcValue: string = 'http://localhost/assets/logo.png';
+    const expectedAltValue: string = 'logo';
+
+    // Act
+    render(<Header />);
+
+    const image = screen.getByRole('img') as HTMLImageElement;
+
+    // Assert
+    expect(image.src).toEqual(expectedSrcValue);
+    expect(image.alt).toEqual(expectedAltValue);
+  });
+});

--- a/front/src/common-app/components/header/header.component.tsx
+++ b/front/src/common-app/components/header/header.component.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Typography, Divider } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import * as classes from './header.styles';
 
 interface Props {}


### PR DESCRIPTION
@juanpms2, in header component we are using a h4 tag instead h1. Why? Thinking about accessibility, I believe whould be better to use a h1 heading.
closes #65 